### PR TITLE
Menambahkan Fitur Pengaturan Akun untuk role Penguji

### DIFF
--- a/app/Http/Controllers/Penguji/ProfilController.php
+++ b/app/Http/Controllers/Penguji/ProfilController.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace App\Http\Controllers\Penguji;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Storage;
+use Inertia\Inertia;
+use App\Models\Osce;
+use App\Models\Mahasiswa;
+use App\Models\Penguji;
+use App\Models\Stase;
+use Illuminate\Validation\Rule; // Import ini untuk validasi unik
+
+class ProfilController extends Controller
+{
+    public function show_profile()
+    {
+        $penguji = Auth::user();
+
+        // Sesuaikan dengan model Anda: gunakan 'path_gambar'
+        $penguji->path_gambar = $penguji->path_gambar ? ($penguji->path_gambar) : null;
+
+        return Inertia::render('Penguji/PengaturanAkun', [
+            // Kirim 'user' ke props 'user' di frontend
+            'user' => $penguji, 
+        ]);
+    }
+
+    /**
+     * 🔹 [FUNGSI BARU] Update Akun (Profil DAN/ATAU Password)
+     * Ini adalah satu-satunya fungsi yang dipanggil oleh tombol "Simpan"
+     */
+    public function update_account(Request $request)
+    {
+        $penguji = Auth::user();
+
+        // --- Validasi ---
+        // Kita validasi semua input yang mungkin
+        $request->validate([
+            // Data Profil
+            // (Sesuai Pengguna.php: 'username' dan 'path_gambar')
+            // 'username' => [
+            //     'required', 
+            //     'string', 
+            //     'max:255',
+            //     // Pastikan username unik, KECUALI untuk diri sendiri
+            //     Rule::unique('pengguna', 'username')->ignore($penguji->id_pengguna, 'id_pengguna')
+            // ],
+            'foto' => ['nullable', 'image', 'mimes:jpg,jpeg,png,gif', 'max:1024'], // 1MB Sesuai UI
+
+            // Data Password (HANYA JIKA diisi)
+            // 'confirmed' akan cek 'new_password_confirmation'
+            'new_password' => ['nullable', 'string', 'min:6', 'confirmed'],
+            'old_password' => ['nullable', 'string'],
+            'delete_foto' => ['nullable', 'boolean'],
+        ]);
+
+        // --- Logika Update Profil ---
+        // (Selalu update username & foto jika ada)
+
+        // 1. Update Username
+        // $penguji->username = $request->username;
+
+        // --- LOGIKA FOTO DIPERBARUI ---
+        // Cek apakah frontend mengirim 'delete_foto: true'
+        if ($request->boolean('delete_foto')) {
+            // 1. HAPUS FOTO
+            if ($penguji->path_gambar) {
+                $oldPath = str_replace('storage/', '', $penguji->path_gambar);
+                Storage::disk('public')->delete($oldPath);
+            }
+            $penguji->path_gambar = null; // Set 'path_gambar' di DB menjadi null
+        }
+        // 2. Update Foto (jika ada file baru)
+        elseif ($request->hasFile('foto')) {
+            // Hapus foto lama
+            if ($penguji->path_gambar) {
+                $oldPath = str_replace('storage/', '', $penguji->path_gambar);
+                Storage::disk('public')->delete($oldPath);
+            }
+            // Simpan foto baru
+            $fotoPath = $request->file('foto')->store('profilpenguji', 'public');
+            $penguji->path_gambar = 'storage/' . $fotoPath;
+        }
+
+        // --- Logika Update Password ---
+        
+        // Cek JIKA pengguna MENGISI field password baru
+        if ($request->filled('new_password')) {
+            
+            // Jika password baru diisi, password lama WAJIB benar
+            if (!Hash::check($request->old_password, $penguji->password)) {
+                // Kirim error HANYA untuk field old_password
+                return back()->withErrors([
+                    'old_password' => 'Password lama tidak sesuai.',
+                ]);
+            }
+            
+            // 3. Update Password
+            // (Model Pengguna.php Anda sudah punya 'password' => 'hashed' cast,
+            // jadi kita bisa langsung set nilainya)
+            $penguji->password = $request->new_password;
+        }
+        
+        // Simpan semua perubahan (username, foto, dan/atau password)
+        $penguji->save();
+
+        return back()->with('success', 'Profil berhasil diperbarui!');
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,20 +1,21 @@
 <?php
 
-use Inertia\Inertia; // Pastikan Inertia di-import
 use App\Models\TahunAkademik;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\AuthController;
 use App\Http\Controllers\Admin\AdminController;
 use App\Http\Controllers\Admin\OsceController; 
 use App\Http\Controllers\Admin\StaseController;
-use App\Http\Controllers\Admin\PengujiController;
+use Inertia\Inertia; // Pastikan Inertia di-import
 use App\Http\Controllers\Admin\MahasiswaController;
 use App\Http\Controllers\Admin\OsceStaseController;
+use App\Http\Controllers\Admin\PengujiController;
 use App\Http\Controllers\Admin\KompetensiController;
 use App\Http\Controllers\Admin\OsceJadwalController;
 use App\Http\Controllers\Admin\RekapNilaiController;
 use App\Http\Controllers\Admin\AspekPenilaianController;
 use App\Http\Controllers\Admin\OsceEnrollmentController;
+use App\Http\Controllers\Penguji\ProfilController;
 
 /*
 |--------------------------------------------------------------------------
@@ -34,6 +35,12 @@ Route::middleware('guest')->group(function () {
 });
 Route::post('/logout', [AuthController::class, 'logout'])->name('logout')->middleware('auth');
 
+Route::prefix('penguji')->middleware(['auth', 'role:penguji'])->name('penguji.')->group(function () {
+
+    // --- Dashboard & Akun ---
+    Route::get('/pengaturan-akun', [ProfilController::class, 'show_profile'])->name('account.show');
+    Route::post('/pengaturan-akun', [ProfilController::class, 'update_account'])->name('account.update');
+});
 
 // =========================
 // === RUTE UNTUK ADMIN ===

--- a/tests/Feature/ProfilControllerTest.php
+++ b/tests/Feature/ProfilControllerTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Tests\Feature\Penguji;
+
+use App\Models\Pengguna;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test; // <-- 1. IMPORT SINTAKS BARU
+
+class ProfilControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private Pengguna $penguji;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->penguji = Pengguna::factory()->create([
+            'jenis_role' => 'penguji',
+            'password' => 'password123' // Pastikan factory Anda membuat ini
+        ]);
+        $this->actingAs($this->penguji);
+    }
+
+    #[Test] // <-- 2. GUNAKAN SINTAKS BARU
+    public function penguji_can_successfully_update_their_password(): void
+    {
+        $response = $this->post(route('penguji.account.update'), [
+            'old_password' => 'password123', 
+            'new_password' => 'password_baru_123',
+            'new_password_confirmation' => 'password_baru_123',
+        ]);
+
+        $response->assertRedirect();
+        $response->assertSessionHas('success');
+        $this->penguji->refresh();
+        $this->assertTrue(Hash::check('password_baru_123', $this->penguji->password));
+    }
+
+    #[Test] // <-- 2. GUNAKAN SINTAKS BARU
+    public function password_update_fails_if_old_password_is_incorrect(): void
+    {
+        $response = $this->post(route('penguji.account.update'), [
+            'old_password' => 'password_salah',
+            'new_password' => 'password_baru_123',
+            'new_password_confirmation' => 'password_baru_123',
+        ]);
+
+        $response->assertSessionHasErrors('old_password');
+        $this->assertTrue(Hash::check('password123', $this->penguji->fresh()->password));
+    }
+
+    #[Test] // <-- 2. GUNAKAN SINTAKS BARU
+    public function penguji_can_upload_a_new_profile_photo(): void
+    {
+        Storage::fake('public');
+
+        // 3. UBAH DARI ->image() MENJADI ->create() UNTUK MENGHINDARI ERROR GD
+        $file = UploadedFile::fake()->create('avatar.jpg', 100); // Buat file 100kb
+
+        $response = $this->post(route('penguji.account.update'), [
+            'foto' => $file,
+        ]);
+
+        $response->assertRedirect();
+        $response->assertSessionHas('success');
+        Storage::disk('public')->assertExists('profilpenguji/' . $file->hashName());
+        $this->penguji->refresh();
+        $this->assertEquals('storage/profilpenguji/' . $file->hashName(), $this->penguji->path_gambar);
+    }
+
+    #[Test] // <-- 2. GUNAKAN SINTAKS BARU
+    public function penguji_can_delete_their_profile_photo(): void
+    {
+        Storage::fake('public');
+        
+        // 3. UBAH DARI ->image() MENJADI ->create()
+        $file = UploadedFile::fake()->create('avatar.jpg', 100)->store('profilpenguji', 'public');
+        $this->penguji->update(['path_gambar' => 'storage/' . $file]);
+
+        Storage::disk('public')->assertExists($file);
+
+        $response = $this->post(route('penguji.account.update'), [
+            'delete_foto' => true,
+        ]);
+
+        $response->assertRedirect();
+        $response->assertSessionHas('success');
+        Storage::disk('public')->assertMissing($file);
+        $this->assertNull($this->penguji->fresh()->path_gambar);
+    }
+}


### PR DESCRIPTION
Pull request ini menambahkan fitur baru yang krusial, yaitu halaman Pengaturan Akun untuk user dengan role Penguji. Fitur ini memungkinkan penguji untuk mengelola data pribadi mereka, termasuk:
1. Mengganti atau menghapus foto profil.
2. Memperbarui password mereka (dengan validasi password lama).

Perubahan Utama

- Controller Baru: Membuat App\Http\Controllers\Penguji\ProfilController.php.
- Method show_profile() disiapkan untuk menampilkan halaman pengaturan akun (GET).
- Method update_account() (POST) dibuat sebagai satu endpoint untuk menangani semua logika pembaruan, baik itu profil (foto) maupun password.

Logika Update

- Foto: Menambahkan logika untuk meng-upload foto baru (profilpenguji/), yang secara otomatis menghapus foto lama jika ada.
- Hapus Foto: Menambahkan logika untuk menghapus foto profil jika delete_foto: true dikirim.
- Password: Menambahkan logika untuk update password, yang hanya berjalan jika new_password diisi dan old_password yang dimasukkan valid.

Rute Baru: Menambahkan rute GET dan POST untuk /penguji/profil (nama rute: penguji.account.show dan penguji.account.update).

Test Fitur Baru

- Membuat file test baru tests/Feature/Penguji/ProfileUpdateTest.php.
- Test ini mencakup semua skenario di controller:
- Berhasil update password.
- Gagal update password (password lama salah).
- Berhasil upload foto profil baru (dan memverifikasi path).
- Berhasil hapus foto profil.

File test ini sudah menggunakan sintaks modern PHPUnit (Atribut #[Test]).